### PR TITLE
Add Koa Backend

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "arangobnb-tutorial",
   "private": true,
   "scripts": {
-    "install": "npm run install-vue && npm run install-react",
+    "install": "npm run install-vue && npm run install-react && npm run install-backend",
     "install-backend": "cd ./workspaces/backend && npm install",
     "install-vue": "cd ./workspaces/frontend-vue && npm install --legacy-peer-deps",
     "install-react": "cd ./workspaces/frontend-react && npm install --legacy-peer-deps",

--- a/workspaces/backend/.babelrc.json
+++ b/workspaces/backend/.babelrc.json
@@ -1,0 +1,12 @@
+{
+  "presets": [
+    [
+      "@babel/preset-env",
+      {
+        "targets": {
+          "node": "current"
+        }
+      }
+    ]
+  ]
+}

--- a/workspaces/backend/package.json
+++ b/workspaces/backend/package.json
@@ -1,10 +1,20 @@
 {
   "name": "arangobnb-tutorial-backend",
   "private": true,
+  "scripts": {
+    "dev": "nodemon src/server_start.js",
+    "start": "node src/server_start.js"
+  },
   "dependencies": {
     "koa": "^2.13.1",
     "koa-router": "^10.0.0",
     "koa-body": "^4.2.0",
     "arangojs": "^7.2.0"
+  },
+  "devDependencies": {
+    "nodemon": "^2.0.7",
+    "@babel/core": "^7.12.13",
+    "@babel/register": "^7.12.13",
+    "@babel/preset-env": "^7.12.13"
   }
 }

--- a/workspaces/backend/package.json
+++ b/workspaces/backend/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "arangobnb-tutorial-backend",
+  "private": true,
+  "dependencies": {
+    "koa": "^2.13.1",
+    "koa-router": "^10.0.0",
+    "koa-body": "^4.2.0",
+    "arangojs": "^7.2.0"
+  }
+}

--- a/workspaces/backend/src/api.js
+++ b/workspaces/backend/src/api.js
@@ -1,0 +1,33 @@
+import KoaRouter from "koa-router";
+
+function sendResponse(ctx, response, status = 200) {
+  ctx.status = status;
+  ctx.body = JSON.stringify(response);
+  ctx.type = "application/json";
+}
+
+const ApiRouter = new KoaRouter();
+
+ApiRouter.use("(.*)", async (ctx, next) => {
+  console.log("Hit the backend API");
+
+  try {
+    await next();
+  } catch (e) {
+    sendResponse(ctx, {
+      error: e.message,
+    }, 500)
+  }
+})
+
+ApiRouter.all("/api/test", async (ctx) => {
+  sendResponse(ctx, {
+    text: "Hello, world!",
+  });
+})
+
+ApiRouter.all("(.*)", async (ctx) => {
+  sendResponse(ctx, { text: "Nothing to see here" }, 404);
+})
+
+export { ApiRouter };

--- a/workspaces/backend/src/arangojs-client.js
+++ b/workspaces/backend/src/arangojs-client.js
@@ -1,0 +1,14 @@
+import { Database } from "arangojs";
+import { ServerConfig } from "./server_config";
+
+function getArangoDbClient() {
+  const config = { url: ServerConfig.arangodb_url };
+
+  if (ServerConfig.arangodb_encoded_ca) {
+    config.agentOptions = { ca: Buffer.from(ServerConfig.arangodb_encoded_ca, "base64") };
+  }
+
+  return new Database(config);
+}
+
+export const ArangoClient = getArangoDbClient();

--- a/workspaces/backend/src/server.js
+++ b/workspaces/backend/src/server.js
@@ -1,0 +1,1 @@
+const koa = require("koa");

--- a/workspaces/backend/src/server.js
+++ b/workspaces/backend/src/server.js
@@ -1,4 +1,4 @@
-import "./server_config";
+import { ServerConfig } from "./server_config";
 import Koa from "koa";
 import { ApiRouter } from "./api";
 
@@ -6,8 +6,6 @@ const App = new Koa();
 
 App.use(ApiRouter.routes());
 
-const port = 5000;
-
-App.listen(port, () => {
-  console.log(`ArangoBnb API Backend listening on :${port}`)
+App.listen(ServerConfig.server_port, () => {
+  console.log(`ArangoBnb API Backend listening on :${ServerConfig.server_port}`)
 });

--- a/workspaces/backend/src/server.js
+++ b/workspaces/backend/src/server.js
@@ -1,1 +1,13 @@
-const koa = require("koa");
+import "./server_config";
+import Koa from "koa";
+import { ApiRouter } from "./api";
+
+const App = new Koa();
+
+App.use(ApiRouter.routes());
+
+const port = 5000;
+
+App.listen(port, () => {
+  console.log(`ArangoBnb API Backend listening on :${port}`)
+});

--- a/workspaces/backend/src/server_config.js
+++ b/workspaces/backend/src/server_config.js
@@ -1,4 +1,5 @@
 export const ServerConfig = {
+  server_port: 5000,
   arangodb_url: "",
-  arangodb_encoded_ca: ""
+  arangodb_encoded_ca: "",
 };

--- a/workspaces/backend/src/server_config.js
+++ b/workspaces/backend/src/server_config.js
@@ -1,0 +1,4 @@
+export const ServerConfig = {
+  arangodb_url: "",
+  arangodb_encoded_ca: ""
+};

--- a/workspaces/backend/src/server_start.js
+++ b/workspaces/backend/src/server_start.js
@@ -1,0 +1,2 @@
+require("@babel/register");
+require("./server.js");


### PR DESCRIPTION
This is the start of the koa backend part of the project:

* Has easy route configuration inside `api.js`
  * Current test route `/api/test` for first 200 response, the rest return 404
* Has other global configuration values to be set inside `server_config.js`
* Start the `dev` environment (auto-reload on changes) with `npm run dev`